### PR TITLE
修改PropTypes的引入方式

### DIFF
--- a/example/common/Nav.js
+++ b/example/common/Nav.js
@@ -4,6 +4,7 @@
  */
 
 var React = require('react');
+var PropTypes require('prop-types');
 
 var NavItem = require('./NavItem');
 
@@ -33,7 +34,7 @@ class Nav extends React.Component {
 }
 
 Nav.propsTypes = {
-    components: React.PropTypes.array.isRequired
+    components: PropTypes.array.isRequired
 };
 
 module.exports = Nav;

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "react-dom": "^0.14.8||^15.4.0",
     "react-motion": "^0.4.2",
     "react-sticky-state": "^2.1.5",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "prop-types": "^15.5.10"
   },
   "babel": {
     "env": {

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Dialog from './Dialog';
 import Button from './Button';
 import createCommand from './dialog/commander';

--- a/src/BoxGroup.js
+++ b/src/BoxGroup.js
@@ -4,7 +4,8 @@
  * @author leon<ludafa@outlook.com>
  */
 
-import React, {PropTypes, Children} from 'react';
+import React, {Children} from 'react';
+import PropTypes from 'prop-types';
 import Option from './boxgroup/Option';
 import {create} from 'melon-core/classname/cxBuilder';
 import InputComponent from 'melon-core/InputComponent';

--- a/src/Button.js
+++ b/src/Button.js
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import TouchRipple from './ripples/TouchRipple';
 import omit from 'lodash/omit';
@@ -59,6 +60,6 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
-    hasRipple: React.PropTypes.bool,
-    disabled: React.PropTypes.bool
+    hasRipple: PropTypes.bool,
+    disabled: PropTypes.bool
 };

--- a/src/Card.js
+++ b/src/Card.js
@@ -13,6 +13,7 @@ const cx = create('Card');
 /**
  * melon/Card
  *
+ * @class
  * @param {Object}  props           属性
  * @return {ReactElement}
  */

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -3,8 +3,8 @@
  * @author Ma63d(chuck7liu@gmail.com)
  */
 
-import React, {Component, PropTypes} from 'react';
-
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Icon from './Icon';
 
 // import {emphasize} from './common/util/color';

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Dialog from './Dialog';
 import Button from './Button';
 import createCommand from './dialog/commander';

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes, cloneElement} from 'react';
+import React, {Component, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Mask from './Mask';
 import * as dom from './common/util/dom';

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Mask from './Mask';
 import {create} from 'melon-core/classname/cxBuilder';
 import * as dom from './common/util/dom';

--- a/src/DropDownMenu.js
+++ b/src/DropDownMenu.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Menu from './Menu';
 import Popover from './Popover';
 

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import omit from 'lodash/omit';
 

--- a/src/IconMenu.js
+++ b/src/IconMenu.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Button from './Button';
 import Icon from './Icon';
 import Menu from './Menu';

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import {
     unstable_renderSubtreeIntoContainer,

--- a/src/Link.js
+++ b/src/Link.js
@@ -15,6 +15,7 @@ const cx = create('Link');
 /**
  * melon/Link
  *
+ * @class
  * @param {Object} props     属性
  * @return {ReactElement}
  */

--- a/src/Mask.js
+++ b/src/Mask.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import * as windowScrollHelper from './dialog/windowScrollHelper';
 import omit from 'lodash/omit';

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes, Children, cloneElement} from 'react';
+import React, {Component, Children, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import MenuItem from './menu/MenuItem';
 import Divider from './Divider';
 import {create} from 'melon-core/classname/cxBuilder';

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes, Children, cloneElement} from 'react';
+import React, {Component, Children, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import NavigationItem from './navigtaion/Item';
 import NavigationHeader from './navigtaion/Header';
 import Divider from './Divider';

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Icon from './Icon';
 import {create} from 'melon-core/classname/cxBuilder';
 import {range} from 'melon-core/util/array';

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Layer from './Layer';
 import align from 'dom-align';
 import {Motion, spring} from 'react-motion';

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -4,7 +4,8 @@
  * @author leon<ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('Progress');

--- a/src/Region.js
+++ b/src/Region.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Selector from './region/Selector';
 import Area from './region/Area';

--- a/src/ScrollView.js
+++ b/src/ScrollView.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Bar from './scrollview/Bar';
 import {create} from 'melon-core/classname/cxBuilder';
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes, Children} from 'react';
+import React, {Children} from 'react';
+import PropTypes from 'prop-types';
 import Icon from './Icon';
 import InputComponent from 'melon-core/InputComponent';
 import Group from './select/OptionGroup';

--- a/src/SelectableTable.js
+++ b/src/SelectableTable.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Table from './Table';
 import SelectorColumn from './table/SelectorColumn';
 import SelectorRow from './table/SelectorRow';

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -3,7 +3,8 @@
  * @author cxtom <cxtom2008@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import InputComponent from 'melon-core/InputComponent';

--- a/src/SnackBar.js
+++ b/src/SnackBar.js
@@ -4,10 +4,10 @@
  * @author leon<ludafa@outlook.com>
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Button from './Button';
-import * as dom from './common/util/dom';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('SnackBar');

--- a/src/Table.js
+++ b/src/Table.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes, Children, cloneElement} from 'react';
+import React, {Component, Children, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import Row from './table/Row';
 import {create} from 'melon-core/classname/cxBuilder';
 import Column from './table/Column';

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes, cloneElement, Children} from  'react';
+import React, {Component, cloneElement, Children} from  'react';
+import PropTypes from 'prop-types';
 import Tab from './tabs/Tab';
 import TabPanel from  './tabs/Panel';
 import {create} from 'melon-core/classname/cxBuilder';

--- a/src/TextBox.js
+++ b/src/TextBox.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import FloatingLabel from './textbox/FloatLabel';
 import TextBoxInput from './textbox/Input';

--- a/src/Title.js
+++ b/src/Title.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('Title');

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -5,7 +5,8 @@
  */
 
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import InputComponent from 'melon-core/InputComponent';
 import {create} from 'melon-core/classname/cxBuilder';
 import CenterRipple from './ripples/CenterRipple';

--- a/src/ToolBar.js
+++ b/src/ToolBar.js
@@ -11,6 +11,7 @@ const cx = create('ToolBar');
 /**
  * melon/ToolBar
  *
+ * @class
  * @param {Object}  props        属性
  * @return {ReactElement}
  */

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Popover from './Popover';
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -4,7 +4,8 @@
  *         leon<ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes, cloneElement, Children} from 'react';
+import React, {Component, cloneElement, Children} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {create} from 'melon-core/classname/cxBuilder';
 import TreeNode from './tree/TreeNode';

--- a/src/Uploader.js
+++ b/src/Uploader.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Button from './Button';
 import Icon from './Icon';
 import Progress from './Progress';

--- a/src/Zippy.js
+++ b/src/Zippy.js
@@ -3,7 +3,9 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
 
 import {create} from 'melon-core/classname/cxBuilder';
 

--- a/src/boxgroup/Option.js
+++ b/src/boxgroup/Option.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Icon from '../Icon';
 import CenterRipple from '../ripples/CenterRipple';

--- a/src/breadcrumb/Item.js
+++ b/src/breadcrumb/Item.js
@@ -4,6 +4,7 @@
   */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('BreadcrumbItem');
@@ -27,5 +28,5 @@ export default function BreadcrumbItem(props) {
 }
 
 BreadcrumbItem.propTypes = {
-    href: React.PropTypes.string
+    href: PropTypes.string
 };

--- a/src/dialog/DialogWindow.js
+++ b/src/dialog/DialogWindow.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import shallowEqual from 'melon-core/util/shallowEqual';
 

--- a/src/menu/MenuItem.js
+++ b/src/menu/MenuItem.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {PureComponent, PropTypes} from 'react';
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Icon from '../Icon';
 import TouchRipple from '../ripples/TouchRipple';

--- a/src/navigtaion/Item.js
+++ b/src/navigtaion/Item.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, Children, PropTypes} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Icon from '../Icon';
 import TouchRipple from '../ripples/TouchRipple';

--- a/src/region/Area.js
+++ b/src/region/Area.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Selector from './Selector';
 import Province from './Province';

--- a/src/region/City.js
+++ b/src/region/City.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import {create} from 'melon-core/classname/cxBuilder';
 import Selector from './Selector';

--- a/src/region/Province.js
+++ b/src/region/Province.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Selector from './Selector';
 import * as helper from './helper';

--- a/src/region/Selector.js
+++ b/src/region/Selector.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Icon from '../Icon';
 import {create} from 'melon-core/classname/cxBuilder';
 

--- a/src/ripples/CenterRipple.js
+++ b/src/ripples/CenterRipple.js
@@ -4,7 +4,8 @@
  */
 
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import RippleCircle from './RippleCircle';
 import {spring, TransitionMotion} from 'react-motion';

--- a/src/ripples/RippleCircle.js
+++ b/src/ripples/RippleCircle.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 export default class RippleCircle extends Component {
 

--- a/src/ripples/TouchRipple.js
+++ b/src/ripples/TouchRipple.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import RippleCircle from './RippleCircle';
 import * as dom from '../common/util/dom';

--- a/src/scrollview/Bar.js
+++ b/src/scrollview/Bar.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import * as dom from '../common/util/dom';
 import {throttle} from '../common/util/fn';

--- a/src/select/Option.js
+++ b/src/select/Option.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('SelectOption');

--- a/src/select/OptionGroup.js
+++ b/src/select/OptionGroup.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Children, PropTypes} from 'react';
+import React, {Children} from 'react';
+import PropTypes from 'prop-types';
 import Option from './Option';
 import {create} from 'melon-core/classname/cxBuilder';
 

--- a/src/slider/Bar.js
+++ b/src/slider/Bar.js
@@ -3,7 +3,8 @@
  * @author cxtom(cxtom2008@gmail.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 import Tooltip from '../Tooltip';

--- a/src/table/Cell.js
+++ b/src/table/Cell.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import shallowEqual from 'melon-core/util/shallowEqual';
 

--- a/src/table/Column.js
+++ b/src/table/Column.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Tooltip from '../Tooltip';
 import {create} from 'melon-core/classname/cxBuilder';
 import Icon from '../Icon';

--- a/src/table/Row.js
+++ b/src/table/Row.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import TableCell from './Cell';
 import shallowEqual from 'melon-core/util/shallowEqual';

--- a/src/table/SelectorColumn.js
+++ b/src/table/SelectorColumn.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import Icon from '../Icon';
 import Column from './Column';

--- a/src/table/SelectorRow.js
+++ b/src/table/SelectorRow.js
@@ -3,7 +3,7 @@
  * @author leon <lupengyu@baidu.com>
  */
 
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import Row from './Row';
 
 /**

--- a/src/table/TableBody.js
+++ b/src/table/TableBody.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import TableRow from './Row';
 import shallowEqual from 'melon-core/util/shallowEqual';

--- a/src/table/TextEditor.js
+++ b/src/table/TextEditor.js
@@ -3,7 +3,8 @@
  * @author leon <ludafa@outlook.com>
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Popover from '../Popover';
 import TextBox from '../TextBox';
 import Button from '../Button';

--- a/src/tabs/Panel.js
+++ b/src/tabs/Panel.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('TabsPanel');
@@ -11,6 +12,7 @@ const cx = create('TabsPanel');
 /**
  * melon/Tabs/TabPanel
  *
+ * @class
  * @param {Object}  props        属性
  * @param {boolean} props.active 是否选中
  * @return {ReactElement}

--- a/src/tabs/Tab.js
+++ b/src/tabs/Tab.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('TabsItem');

--- a/src/textbox/FloatLabel.js
+++ b/src/textbox/FloatLabel.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('TextBoxFloatingLabel');

--- a/src/textbox/Input.js
+++ b/src/textbox/Input.js
@@ -3,7 +3,8 @@
  * @author leon(ludafa@outlook.com)
  */
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 
 const cx = create('TextBoxInput');

--- a/src/tree/TreeNode.js
+++ b/src/tree/TreeNode.js
@@ -3,7 +3,8 @@
  * @author cxtom<cxtom2008@gmail.com>
  */
 
-import React, {Component, PropTypes, Children} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 import {create} from 'melon-core/classname/cxBuilder';
 import Icon from '../Icon';
 import omit from 'lodash/omit';


### PR DESCRIPTION
PropTypes 将会在 React v16.0 版本中删除，现在需要在 [prop-types](https://github.com/facebook/prop-types)库中引入。